### PR TITLE
Switch to section symbol formatting, fix color NPE

### DIFF
--- a/NetworkLibrary/src/club/moddedminecraft/polychat/networking/io/ChatMessage.java
+++ b/NetworkLibrary/src/club/moddedminecraft/polychat/networking/io/ChatMessage.java
@@ -23,30 +23,30 @@ import java.io.IOException;
 
 public final class ChatMessage extends AbstractMessage {
     protected static final short MESSAGE_TYPE_ID = 1;
-    private final String username, message, componentJson;
+    private final String username, message, formattedMessage;
 
     protected ChatMessage(DataInputStream dataInputStream) throws IOException {
         username = dataInputStream.readUTF();
         message = dataInputStream.readUTF();
-        componentJson = dataInputStream.readUTF();
+        formattedMessage = dataInputStream.readUTF();
     }
 
-    public ChatMessage(String username, String message, String componentJson) {
+    public ChatMessage(String username, String message, String formattedMessage) {
         this.username = username;
         this.message = message;
-        this.componentJson = componentJson;
+        this.formattedMessage = formattedMessage;
     }
 
     public String getUsername() {
-        return username;
+                                      return username;
     }
 
     public String getMessage() {
         return message;
     }
 
-    public String getComponentJson() {
-        return componentJson;
+    public String getFormattedMessage() {
+        return formattedMessage;
     }
 
     @Override
@@ -54,7 +54,7 @@ public final class ChatMessage extends AbstractMessage {
         dataOutputStream.writeShort(MESSAGE_TYPE_ID);
         dataOutputStream.writeUTF(username);
         dataOutputStream.writeUTF(message);
-        dataOutputStream.writeUTF(componentJson);
+        dataOutputStream.writeUTF(formattedMessage);
     }
 
 }

--- a/NetworkLibrary/src/club/moddedminecraft/polychat/networking/io/PlayerStatusMessage.java
+++ b/NetworkLibrary/src/club/moddedminecraft/polychat/networking/io/PlayerStatusMessage.java
@@ -26,13 +26,13 @@ import java.io.IOException;
 
 public class PlayerStatusMessage extends AbstractMessage {
     protected static final short MESSAGE_TYPE_ID = 3;
-    private final String userName, serverID, prefixJson;
+    private final String userName, serverID, formattedPrefix;
     private final boolean joined, silent;
 
     public PlayerStatusMessage(String userName, String serverID, String prefixJson, boolean joined, boolean silent) {
         this.userName = userName;
         this.serverID = serverID;
-        this.prefixJson = prefixJson;
+        this.formattedPrefix = prefixJson;
         this.joined = joined;
         this.silent = silent;
     }
@@ -40,7 +40,7 @@ public class PlayerStatusMessage extends AbstractMessage {
     public PlayerStatusMessage(DataInputStream istream) throws IOException {
         this.userName = istream.readUTF();
         this.serverID = istream.readUTF();
-        this.prefixJson = istream.readUTF();
+        this.formattedPrefix = istream.readUTF();
         this.joined = istream.readBoolean();
         this.silent = istream.readBoolean();
     }
@@ -62,8 +62,8 @@ public class PlayerStatusMessage extends AbstractMessage {
         return this.silent;
     }
 
-    public String getPrefixJson() {
-        return this.prefixJson;
+    public String getFormattedPrefix() {
+        return this.formattedPrefix;
     }
 
     @Override
@@ -71,7 +71,7 @@ public class PlayerStatusMessage extends AbstractMessage {
         dataOutputStream.writeShort(MESSAGE_TYPE_ID);
         dataOutputStream.writeUTF(userName);
         dataOutputStream.writeUTF(serverID);
-        dataOutputStream.writeUTF(prefixJson);
+        dataOutputStream.writeUTF(formattedPrefix);
         dataOutputStream.writeBoolean(joined);
         dataOutputStream.writeBoolean(silent);
     }

--- a/NetworkLibrary/src/club/moddedminecraft/polychat/networking/io/ServerStatusMessage.java
+++ b/NetworkLibrary/src/club/moddedminecraft/polychat/networking/io/ServerStatusMessage.java
@@ -27,18 +27,18 @@ import java.io.IOException;
 //Used for broadcasting server online/offline events
 public class ServerStatusMessage extends AbstractMessage {
     protected static final short MESSAGE_TYPE_ID = 2;
-    private final String serverID, prefixJson;
+    private final String serverID, formattedPrefix;
     private final short state;
 
-    public ServerStatusMessage(String serverID, String prefixJson, short state) {
+    public ServerStatusMessage(String serverID, String formattedId, short state) {
         this.serverID = serverID;
-        this.prefixJson = prefixJson;
+        this.formattedPrefix = formattedId;
         this.state = state;
     }
 
     public ServerStatusMessage(DataInputStream istream) throws IOException {
         this.serverID = istream.readUTF();
-        this.prefixJson = istream.readUTF();
+        this.formattedPrefix = istream.readUTF();
         this.state = istream.readShort();
     }
 
@@ -50,15 +50,15 @@ public class ServerStatusMessage extends AbstractMessage {
         return this.state;
     }
 
-    public String getPrefixJson() {
-        return this.prefixJson;
+    public String getFormattedPrefix() {
+        return this.formattedPrefix;
     }
 
     @Override
     protected void send(DataOutputStream dataOutputStream) throws IOException {
         dataOutputStream.writeShort(MESSAGE_TYPE_ID);
         dataOutputStream.writeUTF(serverID);
-        dataOutputStream.writeUTF(prefixJson);
+        dataOutputStream.writeUTF(formattedPrefix);
         dataOutputStream.writeShort(state);
     }
 }

--- a/Server/src/club/moddedminecraft/polychat/server/PrintMessageQueue.java
+++ b/Server/src/club/moddedminecraft/polychat/server/PrintMessageQueue.java
@@ -39,12 +39,12 @@ public class PrintMessageQueue extends ThreadedQueue<MessageData> {
         put("7", new Color(0xAAAAAA));
         put("8", new Color(0x555555));
         put("9", new Color(0x5555FF));
-        put("a", new Color(0x55FF55));
-        put("b", new Color(0x55FFFF));
-        put("c", new Color(0xFF5555));
-        put("d", new Color(0xFF55FF));
-        put("e", new Color(0xFFFF55));
-        put("f", new Color(0xFFFFFF));
+        put("10", new Color(0x55FF55));
+        put("11", new Color(0x55FFFF));
+        put("12", new Color(0xFF5555));
+        put("13", new Color(0xFF55FF));
+        put("14", new Color(0xFFFF55));
+        put("15", new Color(0xFFFFFF));
     }};
 
     @Override
@@ -109,7 +109,6 @@ public class PrintMessageQueue extends ThreadedQueue<MessageData> {
                         embedSpec.setTitle(message.getServerID() + ": " + message.getCommand());
                     }
                     embedSpec.setDescription(message.getCommandOutput());
-                    Random random = new Random(System.currentTimeMillis());
                     embedSpec.setColor(colorHashMap.get(message.getColor()));
                 }).block();
             }


### PR DESCRIPTION
Major changes (for all repos, not just MMCC/polychat):
* Fix NPE related to setting color of command output embed
* Switch from component formatting to section symbol formatting (compatible with legacy Minecraft versions)
* Improve command output reliability for Bukkit client
* _Might_ fix issues executing commands on live GTNH servers